### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:open-data-plan/pangu.git"
+    "url": "git+https://github.com/open-data-plan/pangu.git"
   },
   "keywords": [
     "cli",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:open-data-plan/pangu.git"
+    "url": "git+https://github.com/open-data-plan/pangu.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:open-data-plan/pangu.git"
+    "url": "git+https://github.com/open-data-plan/pangu.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:open-data-plan/pangu.git"
+    "url": "git+https://github.com/open-data-plan/pangu.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",


### PR DESCRIPTION
## Summary
- update the root package repository URL from SSH shorthand to public `git+https`
- update the three published workspace config packages to use the same public repository metadata URL
- leave runtime code, dependencies, versions, homepage, bugs metadata, and package contents unchanged

## Validation
- `node` metadata assertion for root plus three workspace package manifests
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm pack --dry-run --ignore-scripts --json ./packages/eslint-config`
- `npm pack --dry-run --ignore-scripts --json ./packages/prettier-config`
- `npm pack --dry-run --ignore-scripts --json ./packages/stylelint-config`
- `git diff --check`

## Notes
- `npm run build` currently fails on `master` as well with TypeScript 6 `TS5011` rootDir migration errors, so I left build configuration untouched.
- `npm test` currently references `jest`, which is not installed in the current dependency set.
- ESLint currently resolves to ESLint 9 and rejects the existing `.eslintrc.js` config format, so I did not use the auto-fixing lint script for this metadata-only change.
